### PR TITLE
[Fix]-Props-Issue-In-RelatedAttendee.jsx

### DIFF
--- a/frontend/src/components/RelatedAttendee.jsx
+++ b/frontend/src/components/RelatedAttendee.jsx
@@ -25,7 +25,7 @@ const RelatedAttendee = ({ speciality, docId }) => {
       </p>
       <div className="w-full grid grid-cols-auto gap-4 pt-5 gap-y-6 px-3 sm:px-0">
         {relDoc.slice(0, 5).map((item, index) => (
-          <div
+          <div key={index}
             onClick={() => {
               navigate(`/appointment/${item._id}`);
               scrollTo(0,0);


### PR DESCRIPTION
Fix:  #1 
This pull request resolves a warning thrown by React in the browser console when rendering the RelatedAttendee.jsx component. The warning is raised due to the absence of a unique 'key' prop, which is a precautionary measure to prevent potential issues with component re-renders.


Changes:
Added a unique 'key' prop to the RelatedAttendee.jsx component to resolve the warning.